### PR TITLE
DM-35533: bps report crashes when provided with the old id of a restarted job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,9 +37,7 @@ jobs:
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages
         run: |
-          pip install \
-            flake8 \
-            pytest pytest-flake8 pytest-xdist pytest-openfiles pytest-cov
+          pip install "flake8<5" pytest pytest-flake8 pytest-xdist pytest-openfiles pytest-cov
 
       - name: List installed packages
         run: |

--- a/doc/changes/DM-35533.misc.rst
+++ b/doc/changes/DM-35533.misc.rst
@@ -1,0 +1,1 @@
+Made the plugin always report on the latest run even if the old run id was provided to ``bps report``.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
