### PR TITLE
DM-44668: Update plugin to use retryUnlessExit values.

### DIFF
--- a/doc/changes/DM-44668.bugfix.rst
+++ b/doc/changes/DM-44668.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed report listing auto-memory retry as failed when actually successful.

--- a/doc/changes/DM-44668.feature.rst
+++ b/doc/changes/DM-44668.feature.rst
@@ -1,0 +1,1 @@
+Update plugin to use retryUnlessExit values so WMS won't rerun some failures that will just fail every time.

--- a/python/lsst/ctrl/bps/htcondor/htcondor_service.py
+++ b/python/lsst/ctrl/bps/htcondor/htcondor_service.py
@@ -1611,9 +1611,8 @@ def _htc_job_status_to_wms_state(job):
         wms_state = WmsStates.DELETED
     elif job_status == JobStatus.COMPLETED:
         if (
-            job.get("ExitBySignal", False)
+            (job.get("ExitBySignal", False) and job.get("ExitSignal", 0))
             or job.get("ExitCode", 0)
-            or job.get("ExitSignal", 0)
             or job.get("DAG_Status", 0)
         ):
             wms_state = WmsStates.FAILED

--- a/python/lsst/ctrl/bps/htcondor/htcondor_service.py
+++ b/python/lsst/ctrl/bps/htcondor/htcondor_service.py
@@ -710,7 +710,14 @@ def _translate_job_cmds(cached_vals, generic_workflow, gwjob):
         jobcmds["max_retries"] = f"{gwjob.number_of_retries}"
 
     if gwjob.retry_unless_exit:
-        jobcmds["retry_until"] = f"{gwjob.retry_unless_exit}"
+        if isinstance(gwjob.retry_unless_exit, int):
+            jobcmds["retry_until"] = f"{gwjob.retry_unless_exit}"
+        elif isinstance(gwjob.retry_unless_exit, list):
+            jobcmds["retry_until"] = (
+                f'member(ExitCode, {{{",".join([str(x) for x in gwjob.retry_unless_exit])}}})'
+            )
+        else:
+            raise ValueError("retryUnlessExit must be an integer or a list of integers.")
 
     if gwjob.request_disk:
         jobcmds["request_disk"] = f"{gwjob.request_disk}MB"

--- a/python/lsst/ctrl/bps/htcondor/lssthtc.py
+++ b/python/lsst/ctrl/bps/htcondor/lssthtc.py
@@ -181,6 +181,7 @@ HTC_VALID_JOB_KEYS = {
     "on_exit_hold_reason",
     "on_exit_hold_subcode",
     "max_retries",
+    "retry_until",
     "periodic_release",
     "periodic_remove",
     "accounting_group",

--- a/tests/test_htcondor_service.py
+++ b/tests/test_htcondor_service.py
@@ -37,6 +37,7 @@ from lsst.ctrl.bps import BpsConfig, GenericWorkflowExec, GenericWorkflowJob, Wm
 from lsst.ctrl.bps.htcondor.htcondor_config import HTC_DEFAULTS_URI
 from lsst.ctrl.bps.htcondor.htcondor_service import (
     HTCondorService,
+    JobStatus,
     NodeStatus,
     _get_exit_code_summary,
     _htc_node_status_to_wms_state,
@@ -356,6 +357,29 @@ class HtcStatusToWmsStateTestCase(unittest.TestCase):
         job = {"ClusterId": 1}
         result = _htc_status_to_wms_state(job)
         self.assertEqual(result, WmsStates.MISFIT)
+
+    def testRetrySuccess(self):
+        job = {
+            "NodeStatus": 5,
+            "Node": "8e62c569-ae2e-44e8-be36-d1aee333a129_isr_903342_10",
+            "RetryCount": 0,
+            "ClusterId": 851,
+            "ProcId": 0,
+            "MyType": "JobTerminatedEvent",
+            "EventTypeNumber": 5,
+            "HoldReasonCode": 3,
+            "HoldReason": "Job raised a signal 9. Handling signal as if job has gone over memory limit.",
+            "HoldReasonSubCode": 34,
+            "ToE": {
+                "ExitBySignal": False,
+                "ExitCode": 0,
+            },
+            "JobStatus": JobStatus.COMPLETED,
+            "ExitBySignal": False,
+            "ExitCode": 0,
+        }
+        result = _htc_status_to_wms_state(job)
+        self.assertEqual(result, WmsStates.SUCCEEDED)
 
 
 class TranslateJobCmdsTestCase(unittest.TestCase):


### PR DESCRIPTION
Update plugin to use retryUnlessExit values so WMS won't rerun some failures that will just fail every time.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
