### PR TITLE
DM-48032 : Include non-python data artifacts in Python package

### DIFF
--- a/doc/changes/DM-48032.bugfix.rst
+++ b/doc/changes/DM-48032.bugfix.rst
@@ -1,0 +1,1 @@
+Include non-Python data artifacts when packaging for PyPi distribution, including ``etc/*yaml`` and ``final_post.sh``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ where = ["python"]
 zip-safe = true
 license-files = ["COPYRIGHT", "LICENSE", "bsd_license.txt", "gpl-v3.0.txt"]
 
+[tool.setuptools.package-data]
+"lsst.ctrl.bps.htcondor" = ["etc/*.yaml", "final_post.sh"]
+
 [tool.setuptools.dynamic]
 version = { attr = "lsst_versions.get_lsst_version" }
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
