### PR TITLE
DM-50212: Pass MaxIdle to from_dag function.

### DIFF
--- a/doc/changes/DM-50212.misc.rst
+++ b/doc/changes/DM-50212.misc.rst
@@ -1,0 +1,1 @@
+Explicitly define ``MaxIdle`` to workaround bug where HTCondor overrides config and environment variables when it is responsible for making DAGMan submit file (affects at least certain 24.0.x versions).


### PR DESCRIPTION
Explicitly define MaxIdle to workaround a bug where HTCondor overrides config and environment variables when it is responsible for making DAGMan submit file (affects at least certain 24.0.x versions).

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
