### PR TITLE
DM-55434 : Harden default ProvisioningScript

### DIFF
--- a/doc/changes/DM-55434.bugfix.rst
+++ b/doc/changes/DM-55434.bugfix.rst
@@ -1,0 +1,1 @@
+Add signal handling and resilience to default provisioningScript

--- a/python/lsst/ctrl/bps/htcondor/etc/htcondor_defaults.yaml
+++ b/python/lsst/ctrl/bps/htcondor/etc/htcondor_defaults.yaml
@@ -16,21 +16,44 @@ provisioning:
   provisioningPlatform: "s3df"
   provisioningScript: |
     #!/bin/bash
-    set -e
     set -x
-    while true; do
-        ${CTRL_EXECUTE_DIR}/bin/allocateNodes.py \
-            --account {provisioningAccountingUser} \
-            --auto \
-            --node-count {provisioningNodeCount} \
-            --maximum-wall-clock {provisioningMaxWallTime} \
-            --glidein-shutdown {provisioningMaxIdleTime} \
-            --queue {provisioningQueue} \
-            --nodeset {nodeset} \
-            {provisioningExtraOptions} \
-            {provisioningPlatform}
-        sleep {provisioningCheckInterval}
+
+    allocating=1
+    failures=0
+    max_failures=10
+
+    allocate=("${CTRL_EXECUTE_DIR}/bin/allocateNodes.py" \
+          --account '{provisioningAccountingUser}' \
+          --auto \
+          --node-count '{provisioningNodeCount}' \
+          --maximum-wall-clock '{provisioningMaxWallTime}' \
+          --glidein-shutdown '{provisioningMaxIdleTime}' \
+          --queue '{provisioningQueue}' \
+          --nodeset '{nodeset}' \
+          {provisioningExtraOptions} \
+          '{provisioningPlatform}')
+
+    trap "allocating=0" SIGTERM
+
+    echo "$(date -u): starting provisioningJob"
+    while (( allocating )); do
+        if "${allocate[@]}"; then
+          failures=0
+        else
+          echo "$(date -u): allocatedNodes failed" >&2
+          failures=$((failures + 1))
+        fi
+        if [[ $failures -ge $max_failures ]]; then
+          echo "$(date -u): Too many consecutive allocateNodes failures, exiting" >&2
+          exit 1
+        fi
+        sleep {provisioningCheckInterval} &
+        wait $! || :
     done
+    echo "$(date -u): Shutting down provisioningJob..."
+    sleep 20
+    echo "$(date -u): Running FINAL provisioner"
+    "${allocate[@]}"
     exit 0
   provisioningScriptConfig: |
     config.platform["{provisioningPlatform}"].user.name="${USER}"

--- a/python/lsst/ctrl/bps/htcondor/lssthtc.py
+++ b/python/lsst/ctrl/bps/htcondor/lssthtc.py
@@ -222,6 +222,9 @@ HTC_VALID_JOB_KEYS = {
     "periodic_remove",
     "accounting_group",
     "accounting_group_user",
+    "kill_sig",
+    "want_graceful_removal",
+    "job_max_vacate_time",
 }
 HTC_VALID_JOB_DAG_KEYS = {
     "dir",
@@ -1144,7 +1147,7 @@ class HTCDag(networkx.DiGraph):
         Parameters
         ----------
         job : `HTCJob`
-            HTCJob to add to the HTCDag as a FINAL job.
+            HTCJob to add to the HTCDag as a SERVICE job.
         """
         # Add dag level attributes to each job
         job.add_job_attrs(self.graph["attr"])

--- a/python/lsst/ctrl/bps/htcondor/provisioner.py
+++ b/python/lsst/ctrl/bps/htcondor/provisioner.py
@@ -192,6 +192,9 @@ class Provisioner:
             "executable": f"{self.script_name}",
             "should_transfer_files": "NO",
             "getenv": "True",
+            "kill_sig": "SIGTERM",
+            "want_graceful_removal": "True",
+            "job_max_vacate_time": "60",
         }
         cmds |= {
             "output": str(job.subfile.with_suffix(".$(Cluster).out")),

--- a/tests/test_htcondor_service.py
+++ b/tests/test_htcondor_service.py
@@ -227,7 +227,7 @@ class HTCondorServiceTestCase(unittest.TestCase):
             prov_script = Path(tmpdir) / "provisioningJob.bash"
             self.assertTrue(prov_script.is_file())
             script_contents = prov_script.read_text()
-            self.assertIn(f"--nodeset {timestamp}", script_contents)
+            self.assertIn(f"--nodeset '{timestamp}'", script_contents)
 
     def testSubmitWithConfigPath(self):
         """Only testing value for wms_config_path being passed

--- a/tests/test_provisioner.py
+++ b/tests/test_provisioner.py
@@ -149,6 +149,9 @@ class ProvisionerTestCase(unittest.TestCase):
             "output": f"jobs/{script.stem}/{script.stem}.$(Cluster).out",
             "error": f"jobs/{script.stem}/{script.stem}.$(Cluster).out",
             "log": f"jobs/{script.stem}/{script.stem}.$(Cluster).log",
+            "kill_sig": "SIGTERM",
+            "want_graceful_removal": "True",
+            "job_max_vacate_time": "60",
         }
         dag = HTCDag(name="default")
 


### PR DESCRIPTION
Updates the DAG provisioningJob for better signal handling and to ensure an attempt is made to allocate a glidein for finalJob if it needs one (e.g., glidein has expired but provisioner is evicted before final is submitted).

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
